### PR TITLE
Add links and format dates in parole table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 REDIS_ENABLED=false
 TOKEN_VERIFICATION_ENABLED=false
 
+# Current MPC rails app (check port does not clash with this app)
+LEGACY_APP_URL=http://localhost:3001
+
 # Credentials for allowing user access
 AUTH_CODE_CLIENT_ID=hmpps-typescript-template
 AUTH_CODE_CLIENT_SECRET=clientsecret

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -8,6 +8,7 @@ generic-service:
   env:
     ENVIRONMENT_NAME: DEV
     AUDIT_ENABLED: "false"
+    LEGACY_APP_URL: "https://dev.moic.service.justice.gov.uk"
     INGRESS_URL: "https://manage-pom-cases-dev.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"

--- a/integration_tests/e2e/parole/paroleCases.cy.ts
+++ b/integration_tests/e2e/parole/paroleCases.cy.ts
@@ -14,7 +14,7 @@ context('Listing parole cases', () => {
     cy.task('stubSignIn', { roles: [AuthRole.POM] })
     cy.signIn()
 
-    cy.visit(paths.prisons.parole({ prisonCode: 'LEI' }), { failOnStatusCode: false })
+    cy.visit(paths.parole.cases({ prisonCode: 'LEI' }), { failOnStatusCode: false })
     cy.url().should('contain', '/access-denied')
   })
 
@@ -27,7 +27,9 @@ context('Listing parole cases', () => {
 
     Page.verifyOnPage(ParolePage)
     const parolePage = new ParolePage()
-    parolePage.offenderNames().should('contain', 'John Doe')
+    parolePage.offenderNames().should('contain', 'John Doe\nA1234AA')
     parolePage.pomNames().should('contain', 'MOIC Pom')
+    parolePage.pomRoles().should('contain', 'Supporting')
+    parolePage.paroleDates().should('contain', 'TED:\n01 Jan 2026')
   })
 })

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -16,6 +16,7 @@ const createToken = (userToken: UserToken) => {
   const payload = {
     name: userToken.name || 'john smith',
     user_name: 'USER1',
+    user_id: 12345,
     scope: ['read'],
     auth_source: 'nomis',
     authorities,
@@ -120,6 +121,7 @@ const token = (userToken: UserToken) =>
         access_token: createToken(userToken),
         token_type: 'bearer',
         user_name: 'USER1',
+        user_id: 12345,
         auth_source: 'nomis',
         expires_in: 599,
         scope: 'read',

--- a/integration_tests/pages/parolePage.ts
+++ b/integration_tests/pages/parolePage.ts
@@ -5,8 +5,14 @@ export default class ParolePage extends SignedInPage {
     super('Parole cases')
   }
 
-  offenderNames = () =>
-    cy.get('[data-qa=offender-name-column]').then(cells => cells.map((index, cell) => cell.innerText).get())
+  private getColumnText = (dataQa: string) =>
+    cy.get(`[data-qa=${dataQa}]`).then(cells => cells.map((index, cell) => cell.innerText).get())
 
-  pomNames = () => cy.get('[data-qa=pom-name-column]').then(cells => cells.map((index, cell) => cell.innerText).get())
+  offenderNames = () => this.getColumnText('offender-name-column')
+
+  pomNames = () => this.getColumnText('pom-name-column')
+
+  pomRoles = () => this.getColumnText('pom-role-column')
+
+  paroleDates = () => this.getColumnText('next-parole-date-column')
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "connect-flash": "^0.1.1",
         "connect-redis": "^8.0.1",
         "csrf-sync": "^4.0.3",
+        "date-fns": "^4.1.0",
         "express": "^4.21.2",
         "express-session": "^1.18.1",
         "govuk-frontend": "^5.8.0",
@@ -6491,6 +6492,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dateformat": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "connect-flash": "^0.1.1",
     "connect-redis": "^8.0.1",
     "csrf-sync": "^4.0.3",
+    "date-fns": "^4.1.0",
     "express": "^4.21.2",
     "express-session": "^1.18.1",
     "govuk-frontend": "^5.8.0",

--- a/server/config.ts
+++ b/server/config.ts
@@ -110,4 +110,5 @@ export default {
   dpsComponents: {
     url: get('COMPONENT_API_URL', '', requiredInProduction),
   },
+  legacyAppUrl: get('LEGACY_APP_URL', 'http://localhost:3001', requiredInProduction),
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -10,7 +10,7 @@ export default function routes(services: Services): Router {
 
   router.get(paths.root({}), (_req: Request, res: Response) =>
     res.redirect(
-      paths.prisons.dashboard({
+      paths.pomCases.dashboard({
         // @ts-expect-error - not sure why the property is not found!
         prisonCode: res.locals.user.activeCaseLoadId,
       }),

--- a/server/routes/paths.test.ts
+++ b/server/routes/paths.test.ts
@@ -1,0 +1,50 @@
+import paths from './paths'
+
+describe('paths', () => {
+  it('should generate the correct root path', () => {
+    expect(paths.root({})).toBe('/')
+  })
+
+  it('should generate the correct dashboard path', () => {
+    const prisonCode = 'ABC123'
+    expect(paths.pomCases.dashboard({ prisonCode })).toBe(`/prisons/${prisonCode}/dashboard`)
+  })
+
+  it('should generate the correct parole cases path', () => {
+    const prisonCode = 'ABC123'
+    expect(paths.parole.cases({ prisonCode })).toBe(`/prisons/${prisonCode}/parole_cases`)
+  })
+
+  it('should generate the correct unallocated path', () => {
+    const prisonCode = 'ABC123'
+    expect(paths.allocations.unallocated({ prisonCode })).toBe(`/prisons/${prisonCode}/prisoners/unallocated`)
+  })
+
+  it('should generate the correct allocation show path', () => {
+    const prisonCode = 'ABC123'
+    const caseId = 'CASE123'
+    expect(paths.allocations.show({ prisonCode, caseId })).toBe(`/prisons/${prisonCode}/prisoners/${caseId}/allocation`)
+  })
+
+  it('should generate the correct upcoming handover path', () => {
+    const prisonCode = 'ABC123'
+    expect(paths.handover.upcoming({ prisonCode })).toBe(`/prisons/${prisonCode}/handovers/upcoming`)
+  })
+
+  it('should generate the correct staff poms path', () => {
+    const prisonCode = 'ABC123'
+    expect(paths.staff.poms({ prisonCode })).toBe(`/prisons/${prisonCode}/poms`)
+  })
+
+  it('should generate the correct staff show path', () => {
+    const prisonCode = 'ABC123'
+    const staffId = 'STAFF123'
+    expect(paths.staff.show({ prisonCode, staffId })).toBe(`/prisons/${prisonCode}/poms/${staffId}`)
+  })
+
+  it('should generate the correct staff caseload path', () => {
+    const prisonCode = 'ABC123'
+    const staffId = 'STAFF123'
+    expect(paths.staff.caseload({ prisonCode, staffId })).toBe(`/prisons/${prisonCode}/staff/${staffId}/caseload`)
+  })
+})

--- a/server/routes/paths.ts
+++ b/server/routes/paths.ts
@@ -1,16 +1,33 @@
 import { path } from 'static-path'
 
 const root = path('/')
-
-const prisons = path('/prisons')
-const dashboard = prisons.path(':prisonCode/dashboard')
-const parole = prisons.path(':prisonCode/parole_cases')
+const prisons = path('/prisons/:prisonCode')
+const prisoners = prisons.path('prisoners')
+const handovers = prisons.path('handovers')
+const poms = prisons.path('poms')
+const staff = prisons.path('staff/:staffId')
 
 const paths = {
   root,
-  prisons: {
-    dashboard,
-    parole,
+
+  // This corresponds with the top level navigation header
+  pomCases: {
+    dashboard: prisons.path('dashboard'),
+  },
+  allocations: {
+    unallocated: prisoners.path('unallocated'),
+    show: prisoners.path(':caseId/allocation'),
+  },
+  parole: {
+    cases: prisons.path('parole_cases'),
+  },
+  handover: {
+    upcoming: handovers.path('upcoming'),
+  },
+  staff: {
+    poms,
+    show: poms.path(':staffId'),
+    caseload: staff.path('caseload'),
   },
 }
 

--- a/server/routes/prisons/controller.test.ts
+++ b/server/routes/prisons/controller.test.ts
@@ -29,7 +29,7 @@ afterEach(() => {
 
 describe('Dashboard', () => {
   const rootPath = paths.root({})
-  const dashboardPath = paths.prisons.dashboard({ prisonCode: 'LEI' })
+  const dashboardPath = paths.pomCases.dashboard({ prisonCode: 'LEI' })
 
   it('should redirect to the dashboard page for the prison', () => {
     return request(app).get(rootPath).expect(302).expect('Location', dashboardPath)
@@ -57,7 +57,7 @@ describe('Parole', () => {
     paroleService.upcomingCases.mockReturnValue(null)
 
     const prisonCode = 'LEI'
-    const parolePath = paths.prisons.parole({ prisonCode })
+    const parolePath = paths.parole.cases({ prisonCode })
 
     return request(app)
       .get(parolePath)

--- a/server/routes/prisons/controller.ts
+++ b/server/routes/prisons/controller.ts
@@ -15,7 +15,7 @@ export default class PrisonRoutes {
     res.render('pages/prisons/dashboard')
   }
 
-  parole = async (req: Request, res: Response): Promise<void> => {
+  paroleCases = async (req: Request, res: Response): Promise<void> => {
     await this.auditService.logPageView(Page.PAROLE_CASES_PAGE, {
       who: res.locals.user.username,
       correlationId: req.id,

--- a/server/routes/prisons/index.ts
+++ b/server/routes/prisons/index.ts
@@ -15,8 +15,8 @@ export default function Index({ auditService, paroleService }: Services): Router
 
   const prisonRoutes = new PrisonRoutes(auditService, paroleService)
 
-  get(paths.prisons.dashboard, prisonRoutes.dashboard, [AuthRole.POM, AuthRole.SPO])
-  get(paths.prisons.parole, prisonRoutes.parole, [AuthRole.SPO])
+  get(paths.pomCases.dashboard, prisonRoutes.dashboard, [AuthRole.POM, AuthRole.SPO])
+  get(paths.parole.cases, prisonRoutes.paroleCases, [AuthRole.SPO])
 
   return router
 }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,3 +1,5 @@
+import { format } from 'date-fns'
+
 const properCase = (word: string): string =>
   word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
 
@@ -22,4 +24,8 @@ const initialiseName = (fullName?: string): string | null => {
   return `${array[0][0]}. ${array.reverse()[0]}`
 }
 
-export { properCase, convertToTitleCase, initialiseName }
+const formatDate = (date: Date, pattern: string = 'dd MMM yyyy', defaultValue: string = null) => {
+  return date ? format(date, pattern) : defaultValue
+}
+
+export { properCase, convertToTitleCase, initialiseName, formatDate }

--- a/server/views/macros/navigation.njk
+++ b/server/views/macros/navigation.njk
@@ -1,40 +1,40 @@
 {%- from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation -%}
 
-{% macro primaryNavigation(currentUrl, activeCaseLoadId, userIsSpo, userIsPom) %}
+{% macro primaryNavigation(currentUrl, activeCaseLoadId, staffId, userIsSpo, userIsPom) %}
   {% set items = [
     {
       text: "POM cases",
-      href: paths.prisons.dashboard | toPath({ prisonCode: activeCaseLoadId }),
-      active: currentUrl === paths.prisons.dashboard | toPath({ prisonCode: activeCaseLoadId }),
+      href: paths.pomCases.dashboard | toPath({ prisonCode: activeCaseLoadId }),
+      active: isActiveHeaderSection(currentUrl, paths.pomCases),
       shown: userIsSpo or userIsPom
     },
     {
       text: "Allocations",
-      href: "#allocations",
+      href: paths.allocations.unallocated | toLegacyUrl({ prisonCode: activeCaseLoadId }),
       active: false,
       shown: userIsSpo
     },
     {
       text: "Caseload",
-      href: "#caseload",
+      href: paths.staff.caseload | toLegacyUrl({ prisonCode: activeCaseLoadId, staffId: staffId }),
       active: false,
       shown: userIsPom
     },
     {
       text: "Parole",
-      href: paths.prisons.parole | toPath({ prisonCode: activeCaseLoadId }),
-      active: currentUrl === paths.prisons.parole | toPath({ prisonCode: activeCaseLoadId }),
+      href: paths.parole.cases | toPath({ prisonCode: activeCaseLoadId }),
+      active: isActiveHeaderSection(currentUrl, paths.parole),
       shown: userIsSpo
     },
     {
       text: "Handover",
-      href: "#handover",
+      href: paths.handover.upcoming | toLegacyUrl({ prisonCode: activeCaseLoadId }),
       active: false,
       shown: userIsSpo or userIsPom
     },
     {
       text: "Staff",
-      href: "#staff",
+      href: paths.staff.poms | toLegacyUrl({ prisonCode: activeCaseLoadId }),
       active: false,
       shown: userIsSpo
     }

--- a/server/views/pages/prisons/parole.njk
+++ b/server/views/pages/prisons/parole.njk
@@ -12,37 +12,43 @@
     All cases in this prison with a target hearing date, PED or TED in the next 10 months
   </p>
 
-  <section id="approaching-parole">
-    {% set tableRows = [] %}
-    {% for case in paroleCases %}
-      {% set tableRows = (tableRows.push([
-        {
-          text: case.caseName,
-          attributes: {
-            "data-qa": "offender-name-column"
-          }
-        },
-        {
-          text: case.pomName,
-          attributes: {
-            "data-qa": "pom-name-column"
-          }
-        },
-        {
-          text: case.pomRole,
-          attributes: {
-            "data-qa": "pom-role-column"
-          }
-        },
-        {
-          text: case.paroleDateValue,
-          attributes: {
-            "data-qa": "next-parole-date-column"
-          }
-        }
-      ]), tableRows) %}
-    {% endfor %}
+  {% set tableRows = [] %}
+  {% for case in paroleCases %}
+    {% set caseUrl = paths.allocations.show | toLegacyUrl({ prisonCode: user.activeCaseLoadId, caseId: case.caseId }) %}
+    {% set pomUrl = paths.staff.show | toLegacyUrl({ prisonCode: user.activeCaseLoadId, staffId: '12345' }) %}
 
+    {% set tableRows = (tableRows.push([
+      {
+        html: "<a href="+ caseUrl +">"+ case.caseName +"</a><br><span class='govuk-hint govuk-!-margin-bottom-0'>"+ case.caseId +"</span>",
+        attributes: {
+          "data-qa": "offender-name-column",
+          "data-sort-value": case.caseName
+        }
+      },
+      {
+        html: "<a href="+ pomUrl +">"+ case.pomName +"</a>",
+        attributes: {
+          "data-qa": "pom-name-column",
+          "data-sort-value": case.pomName
+        }
+      },
+      {
+        text: case.pomRole,
+        attributes: {
+          "data-qa": "pom-role-column"
+        }
+      },
+      {
+        html: "<span class='govuk-!-margin-bottom-0'>"+ case.paroleDateType +":</span><br>" + (case.paroleDateValue | formatDate),
+        attributes: {
+          "data-qa": "next-parole-date-column",
+          "data-sort-value": case.paroleDateValue
+        }
+      }
+    ]), tableRows) %}
+  {% endfor %}
+
+  <section id="approaching-parole">
     {{ govukTable({
       attributes: {
         'data-module': 'moj-sortable-table'

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -23,7 +23,7 @@
   {{ feComponents.header | safe }}
 
   {% if user.activeCaseLoadId %}
-    {{ primaryNavigation(currentUrl, user.activeCaseLoadId, userContext.isSpo, userContext.isPom) }}
+    {{ primaryNavigation(currentUrl, user.activeCaseLoadId, user.staffId|string, userContext.isSpo, userContext.isPom) }}
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Note we are missing staff Id from the backend, so a placeholder have been added for now. Also some names formatting will be needed.

During development of the new app, many links will go to the current, rails MPC app, so these links need to refer to the absolute URL of the environment where they are running, exposed as an env variable `LEGACY_APP_URL`.

Once we have functionality for those links in the new app, we just need to swap `toLegacyUrl()` with `toPath()`